### PR TITLE
Fix the green/yellow coloring algorithm

### DIFF
--- a/script.js
+++ b/script.js
@@ -15383,43 +15383,36 @@ function submitGuess() {
   }
 
   stopInteraction()
-  activeTiles.forEach((...params) => flipTile(...params, guess))
+  const colors = computeColors(targetWord, guess)
+  activeTiles.forEach((tile, index, array) => flipTile(tile, index, array, guess, colors[index]))
 }
 
-function computeColor(targetWord, guess, index) {
-  let colors = Array(WORD_LENGTH).fill("wrong")
-  for (var i = 0; i < WORD_LENGTH; ++i) {
-    if (targetWord[i] === guess[i]) {
+function computeColors(targetWord, guess) {
+  const colors = Array(WORD_LENGTH).fill("wrong")
+  const outOfPlace = {}
+  for (let i = 0; i < WORD_LENGTH; ++i) {
+    const letter = targetWord[i]
+    if (guess[i] === letter) {
       colors[i] = "correct"
-    } else if (targetWord.includes(guess[i])) {
-      colors[i] = "wrong-location"
+    } else {
+      outOfPlace[letter] = (outOfPlace[letter] || 0) + 1
     }
   }
-  for (var i = 0; i < WORD_LENGTH; ++i) {
-    if (colors[i] == "wrong-location") {
-      // Only the correct number of tiles should be colored yellow.
-      const letter = guess[i]
-      const targetCount = targetWord.split('').filter((ch) => ch == letter).length
-      const greenCount = Array.from(Array(WORD_LENGTH).keys()).filter((j) => (guess[j] === letter && colors[j] === "correct")).length
-      const maxYellowCount = targetCount - greenCount
-      let currentYellowCount = 0
-      for (var j = 0; j < i; ++j) {
-        if (guess[j] == letter && colors[j] === "wrong-location") {
-          currentYellowCount += 1
-        }
-      }
-      if (currentYellowCount == maxYellowCount) {
-        colors[i] = "wrong"
+  for (let i = 0; i < WORD_LENGTH; ++i) {
+    const letter = guess[i]
+    if (targetWord[i] !== letter) {
+      if (outOfPlace[letter]) {
+        colors[i] = "wrong-location"
+        outOfPlace[letter] -= 1
       }
     }
   }
-  return colors[index]
+  return colors
 }
 
-function flipTile(tile, index, array, guess) {
+function flipTile(tile, index, array, guess, newColor) {
   const letter = tile.dataset.letter
   const key = keyboard.querySelector(`[data-key="${letter}"i]`)
-  const newColor = computeColor(targetWord, guess, index)
 
   setTimeout(() => {
     tile.classList.add("flip")

--- a/script.js
+++ b/script.js
@@ -15386,9 +15386,22 @@ function submitGuess() {
   activeTiles.forEach((...params) => flipTile(...params, guess))
 }
 
+function computeColor(targetWord, guess, index) {
+  const letter = guess[index]
+  if (targetWord[index] === letter) {
+    return "correct"
+  } else if (targetWord.includes(letter)) {
+    return "wrong-location"
+  } else {
+    return "wrong"
+  }
+}
+
 function flipTile(tile, index, array, guess) {
   const letter = tile.dataset.letter
   const key = keyboard.querySelector(`[data-key="${letter}"i]`)
+  const newColor = computeColor(targetWord, guess, index)
+
   setTimeout(() => {
     tile.classList.add("flip")
   }, (index * FLIP_ANIMATION_DURATION) / 2)
@@ -15397,17 +15410,8 @@ function flipTile(tile, index, array, guess) {
     "transitionend",
     () => {
       tile.classList.remove("flip")
-      if (targetWord[index] === letter) {
-        tile.dataset.state = "correct"
-        key.classList.add("correct")
-      } else if (targetWord.includes(letter)) {
-        tile.dataset.state = "wrong-location"
-        key.classList.add("wrong-location")
-      } else {
-        tile.dataset.state = "wrong"
-        key.classList.add("wrong")
-      }
-
+      tile.dataset.state = newColor
+      key.classList.add(newColor)
       if (index === array.length - 1) {
         tile.addEventListener(
           "transitionend",

--- a/script.js
+++ b/script.js
@@ -15387,14 +15387,33 @@ function submitGuess() {
 }
 
 function computeColor(targetWord, guess, index) {
-  const letter = guess[index]
-  if (targetWord[index] === letter) {
-    return "correct"
-  } else if (targetWord.includes(letter)) {
-    return "wrong-location"
-  } else {
-    return "wrong"
+  let colors = Array(WORD_LENGTH).fill("wrong")
+  for (var i = 0; i < WORD_LENGTH; ++i) {
+    if (targetWord[i] === guess[i]) {
+      colors[i] = "correct"
+    } else if (targetWord.includes(guess[i])) {
+      colors[i] = "wrong-location"
+    }
   }
+  for (var i = 0; i < WORD_LENGTH; ++i) {
+    if (colors[i] == "wrong-location") {
+      // Only the correct number of tiles should be colored yellow.
+      const letter = guess[i]
+      const targetCount = targetWord.split('').filter((ch) => ch == letter).length
+      const greenCount = Array.from(Array(WORD_LENGTH).keys()).filter((j) => (guess[j] === letter && colors[j] === "correct")).length
+      const maxYellowCount = targetCount - greenCount
+      let currentYellowCount = 0
+      for (var j = 0; j < i; ++j) {
+        if (guess[j] == letter && colors[j] === "wrong-location") {
+          currentYellowCount += 1
+        }
+      }
+      if (currentYellowCount == maxYellowCount) {
+        colors[i] = "wrong"
+      }
+    }
+  }
+  return colors[index]
 }
 
 function flipTile(tile, index, array, guess) {


### PR DESCRIPTION
Before this patch, it gives wrong (that is, not-following-the-rules-of-Wordle) colors for words containing repeated letters. For example, if the word was `MAXIM` and you guessed `MAMMA`, you'd get colors `GGYYY` instead of the correct `GGY--`.

I think this code is now correct, but I admit I'm not 100% sure, and there might be a cleverer way to do it, too.