### PR TITLE
Fix the backspace key that sometimes eats clicks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,7 @@ body {
 .key > svg {
   width: 1.75em;
   height: 1.75em;
+  pointer-events: none;
 }
 
 .key:hover, .key:focus {


### PR DESCRIPTION
The SVG image on the backspace key needs "pointer-events: none" so that clicking directly on the image will pass through the click event to the button, instead of eating it.