### PR TITLE
Convert upperCase input to lowerCase

### DIFF
--- a/script.js
+++ b/script.js
@@ -15344,6 +15344,11 @@ function handleKeyPress(e) {
     pressKey(e.key)
     return
   }
+  
+  if (e.key.match(/^[A-Z]$/)) {
+    pressKey(e.key.toLowerCase())
+    return
+  }
 }
 
 function pressKey(key) {


### PR DESCRIPTION
At the moment if someone has capslock on or capitalises the first letter of the word out of habit, the app will appear to do nothing.
This change treats the capital letter input as its lowercase equivalent.